### PR TITLE
fix PinchState SparseArray ArrayIndexOutOfBoundsException

### DIFF
--- a/collage-gesture-detector/src/main/java/com/cardinalblue/gesture/state/PinchState.kt
+++ b/collage-gesture-detector/src/main/java/com/cardinalblue/gesture/state/PinchState.kt
@@ -31,6 +31,7 @@ import com.cardinalblue.gesture.IGestureStateOwner
 import com.cardinalblue.gesture.IGestureStateOwner.State.STATE_IDLE
 import com.cardinalblue.gesture.IGestureStateOwner.State.STATE_SINGLE_FINGER_PRESSING
 import java.util.*
+import kotlin.IllegalArgumentException
 
 class PinchState(owner: IGestureStateOwner) : BaseGestureState(owner) {
 
@@ -94,11 +95,13 @@ class PinchState(owner: IGestureStateOwner) : BaseGestureState(owner) {
             MotionEvent.ACTION_MOVE -> {
                 if (downPointerCount >= 2) {
                     // Update stop pointers.
-                    val id1 = mOrderedPointerIds[0]
-                    mStopPointers.setValueAt(id1, Pair(event.getX(0), event.getY(0)))
+                    val idPointer1 = mOrderedPointerIds[0]
+                    mStopPointers.setValueAt(0,
+                            Pair(event.getXbyId(idPointer1), event.getYbyId(idPointer1)))
 
-                    val id2 = mOrderedPointerIds[1]
-                    mStopPointers.setValueAt(id2, Pair(event.getX(1), event.getY(1)))
+                    val idPointer2 = mOrderedPointerIds[1]
+                    mStopPointers.setValueAt(1,
+                            Pair(event.getXbyId(idPointer2), event.getYbyId(idPointer2)))
 
                     // Dispatch callback.
                     owner.listener?.onPinch(
@@ -211,4 +214,20 @@ class PinchState(owner: IGestureStateOwner) : BaseGestureState(owner) {
     override fun onHandleMessage(msg: Message): Boolean {
         return false
     }
+}
+
+fun MotionEvent.getXbyId(pointerId: Int): Float {
+    val pointerIndex = this.findPointerIndex(pointerId)
+
+    if (pointerIndex == -1) throw IllegalArgumentException()
+
+    return this.getX(pointerIndex)
+}
+
+fun MotionEvent.getYbyId(pointerId: Int): Float {
+    val pointerIndex = this.findPointerIndex(pointerId)
+
+    if (pointerIndex == -1) throw IllegalArgumentException()
+
+    return this.getY(pointerIndex)
 }


### PR DESCRIPTION
- `SparseArray.setValueAt(index)` throws `ArrayIndexOutOfBoundsException` [from Android 10](https://developer.android.com/reference/android/util/SparseArray#setValueAt(int,%20E))
- Fix the incorrect SparseArray (id -> index) and MotionEvent parameters (index -> id)

[Trello](https://trello.com/c/ksmipNru/4954-crashlyticsandroid-10-11-crash-on-interacting-with-multiple-fingers)

[Crashlytics](https://console.firebase.google.com/project/api-project-773876082784/crashlytics/app/android:com.cardinalblue.piccollage.google/issues/87dfb8e6fe93d0fa1f2cff4c0b1736ae?time=last-ninety-days)